### PR TITLE
Add basic community page

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -1,0 +1,10 @@
+Community Projects
+==================
+
+These projects from the community are developed on top of Channels:
+
+* Djangobot_, a bi-directional interface server for Slack.
+
+If you'd like to add your project, please submit a PR with a link and brief description.
+
+.. _Djangobot: https://github.com/djangobot/djangobot

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,3 +37,4 @@ Contents:
    reference
    faqs
    asgi
+   community


### PR DESCRIPTION
I've added a small & basic page to link to community projects built around
around Channels. As there are more links, this page might warrant some
sections including how-to's, etc.
